### PR TITLE
Style fixes

### DIFF
--- a/Deauth/boopstrike.py
+++ b/Deauth/boopstrike.py
@@ -22,6 +22,7 @@ from tabulate import tabulate
 from threading import Thread
 from time import sleep, time
 
+
 conf.verb = 0
 
 Channel_Hopper_Flag = True
@@ -38,6 +39,7 @@ Access_Points = []
 Clients = []
 Deauth_Dict = {"Client":[], "APS": []}
 
+
 # CLASSES
 class bcolors:
     HEADER    = "\033[95m"
@@ -48,6 +50,7 @@ class bcolors:
     ENDC      = "\033[0m"
     BOLD      = "\033[1m"
     UNDERLINE = "\033[4m"
+
 
 class Configuration:
     def __init__(self):
@@ -189,6 +192,7 @@ class Configuration:
             exit()
         return
 
+
 def handler_beacon(packet):
     global Mac_Filter_Channel
     global Mac_Filter
@@ -216,6 +220,7 @@ def handler_beacon(packet):
 
     return
 
+
 def handler_data(packet):
     global Access_Points
     global Clients
@@ -242,6 +247,7 @@ def handler_data(packet):
                 Deauth_Dict["Client"].append( [address1, address2, configuration.channel ] )
 
     return
+
 
 def channel_hopper(configuration):
     global Channel_Hopper_Flag
@@ -289,6 +295,7 @@ def channel_hopper(configuration):
         sleep(3)
     return
 
+
 def sniff_packets(packet):
     global Mac_Filter
     global Ignore_Broadcast
@@ -305,6 +312,7 @@ def sniff_packets(packet):
 
     return
 
+
 def check_valid(mac):
     global Ignore_Broadcast
     global Ignore_Multicast
@@ -320,9 +328,11 @@ def check_valid(mac):
             return False
     return True
 
+
 def start_sniffer(configuration):
     sniff(iface=configuration.interface, prn=sniff_packets, store=0)
     return
+
 
 def printer(configuration):
     global Deauth_Dict
@@ -374,9 +384,11 @@ def printer(configuration):
         sleep(timeout)
     return
 
+
 def set_size(height, width):
     stdout.write("\x1b[8;{rows};{cols}t".format(rows=height, cols=width))
     return
+
 
 def int_main(configuration):
     global Channel_Hopper_Flag
@@ -415,6 +427,7 @@ def int_main(configuration):
     printer(configuration)
 
     return 0
+
 
 def display_art():
     print(bcolors.OKBLUE+"""

--- a/Monitor/boop.py
+++ b/Monitor/boop.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 import time
 

--- a/Monitor/boop.py
+++ b/Monitor/boop.py
@@ -306,4 +306,5 @@ def main():
     return (0)
 
 
-main()
+if __name__ == "__main__":
+    main()

--- a/Monitor/boop.py
+++ b/Monitor/boop.py
@@ -11,6 +11,7 @@ import argparse
 from os import system, path, getuid, uname
 from sys import exit, stdout, exc_info
 
+
 class c:
     HEADER    = "\033[95m"
     OKBLUE    = "\033[94m"
@@ -21,6 +22,7 @@ class c:
     ENDC      = "\033[0m"
     BOLD      = "\033[1m"
     UNDERLINE = "\033[4m"
+
 
 class Configuration:
     def __init__(self):
@@ -272,6 +274,7 @@ class Configuration:
         print(c.OKGREEN+" [+] "+c.WHITE+"Card Set to Channel: "+c.HEADER+str(self.channel))
         return
 
+
 def display_art():
     print(c.OKBLUE+"""
  /$$$$$$$
@@ -289,6 +292,7 @@ def display_art():
     print(c.HEADER+"     Codename: Inland Taipan\r\n"+c.BOLD)
     return
 
+
 def main():
     stdout.write("\x1b[8;{rows};{cols}t".format(rows=35, cols=75))
     start = time.time()
@@ -300,5 +304,6 @@ def main():
 
     print(c.OKBLUE+" [+] "+c.WHITE+"Time: "+c.OKGREEN+str(round(time.time() - start, 5)))
     return (0)
+
 
 main()

--- a/Packet-Sniffer/boopsniff.py
+++ b/Packet-Sniffer/boopsniff.py
@@ -25,6 +25,7 @@ from tabulate import tabulate
 from threading import Thread
 from time import sleep, time
 
+
 conf.verb = 0
 
 # GLOBALS
@@ -47,6 +48,7 @@ Global_Recent_Key_Cap = ""
 Global_Handshake_Captures = 0
 Global_Handshake_List = []
 
+
 # CLASSES
 class bcolors:
     HEADER    = "\033[95m"
@@ -57,6 +59,7 @@ class bcolors:
     ENDC      = "\033[0m"
     BOLD      = "\033[1m"
     UNDERLINE = "\033[4m"
+
 
 class Configuration:
     def __init__(self):
@@ -262,6 +265,7 @@ class Configuration:
         print(bcolors.OKGREEN+" [+] Hostname: " + str(uname()[1])+bcolors.ENDC+bcolors.BOLD)
         return
 
+
 class Access_Point:
     def __init__(self, ssid, enc, ch, mac, ven, sig):
         self.mssid = ssid
@@ -278,6 +282,7 @@ class Access_Point:
         self.mssid = ssid
         return
 
+
 class Client:
     def __init__(self, mac, bssid, rssi):
         self.mmac   = mac
@@ -285,6 +290,7 @@ class Client:
         self.msig   = rssi
         self.mnoise = 0
         return
+
 
 # HANDLER
 def handler_beacon(packet):
@@ -377,6 +383,7 @@ def handler_beacon(packet):
 
     return
 
+
 def handler_data(packet):
     global Global_Access_Points
     global Global_Clients
@@ -418,6 +425,7 @@ def handler_data(packet):
             Global_Clients[address1].mnoise += 1
 
     return
+
 
 def handler_eap(packet):
     global Global_Handshake_List
@@ -488,6 +496,7 @@ def handler_eap(packet):
         Global_Handshake_List.append(STA)
     return
 
+
 def handler_probereq(packet):
     global Global_Clients
 
@@ -501,6 +510,7 @@ def handler_probereq(packet):
 
     return
 
+
 def handler_proberes(packet):
     global Global_Access_Points
     global Global_Hidden_SSIDs
@@ -511,6 +521,7 @@ def handler_proberes(packet):
     Global_Handshakes[packet.addr3]['beacon'].append(packet)
     return
 
+
 def get_rssi(decoded):
     rssi = -(256 - ord(decoded[-2:-1]))
 
@@ -520,6 +531,7 @@ def get_rssi(decoded):
     if rssi < -100:
         return -1
     return rssi
+
 
 def channel_hopper(configuration):
     global Global_Channel_Hopper_Flag
@@ -568,6 +580,7 @@ def channel_hopper(configuration):
         sleep(3)
     return
 
+
 def get_access_points(AP):
     global Global_Access_Points
 
@@ -580,6 +593,7 @@ def get_access_points(AP):
         Global_Access_Points[AP].mbeacons,
         Global_Access_Points[AP].mssid[:15]
     ]
+
 
 def get_clients():
     global Global_Access_Points
@@ -598,6 +612,7 @@ def get_clients():
         except:
             pass
     return clients
+
 
 def get_un_clients():
     global Global_Access_Points
@@ -623,6 +638,7 @@ def get_un_clients():
                 ""
             ])
     return clients
+
 
 def printer_thread(configuration):
     global Global_Clients
@@ -669,6 +685,7 @@ def printer_thread(configuration):
         sleep(timeout)
     return
 
+
 def sniff_packets(packet):
     global Global_Mac_Filter
     global Global_Ignore_Broadcast
@@ -699,10 +716,12 @@ def sniff_packets(packet):
 
     return
 
+
 # MISC
 def set_size(height, width):
     stdout.write("\x1b[8;{rows};{cols}t".format(rows=height, cols=width))
     return
+
 
 def display_art():
     print(bcolors.OKBLUE+"""
@@ -716,6 +735,7 @@ def display_art():
     print(bcolors.HEADER+"     Codename: Inland Taipan\r\n"+bcolors.BOLD)
     return
 
+
 def check_valid(mac):
     global Global_Ignore_Broadcast
     global Global_Ignore_Multicast
@@ -728,15 +748,18 @@ def check_valid(mac):
             return False
     return True
 
+
 def create_pcap_filepath():
     if not os.path.isdir("pcaps"):
         os.system("mkdir pcaps")
         os.system("chmod 1777 pcaps/")
     return
 
+
 def start_sniffer(configuration):
     sniff(iface=configuration.interface, prn=sniff_packets, store=0)
     return
+
 
 # MAIN CONTROLLER
 def int_main(configuration):
@@ -789,6 +812,7 @@ def int_main(configuration):
         printer_thread(configuration)
 
     return 0
+
 
 if __name__ == "__main__":
     display_art()

--- a/Packet-Sniffer/boopsniff_gui.py
+++ b/Packet-Sniffer/boopsniff_gui.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 __year__    = [2016, 2017]
 __status__  = "Testing"

--- a/Packet-Sniffer/boopsniff_gui.py
+++ b/Packet-Sniffer/boopsniff_gui.py
@@ -27,6 +27,7 @@ from tabulate import tabulate
 from threading import Thread
 from time import sleep, time
 
+
 # GLOBALS
 Global_Access_Points = {} # MAC, AP OBJECT
 Global_Clients = {} # MAC, CLIENT OBJECT
@@ -45,6 +46,7 @@ Global_Handshake_Captures = 0
 
 Global_My_Gui = ""
 
+
 # CLASSES
 class Color:
     HEADER           = '#%02x%02x%02x' % (30, 144, 255)
@@ -52,6 +54,7 @@ class Color:
     BUTTON_COLOR     = '#%02x%02x%02x' % (242, 163, 189)
     TITLE_BACKGROUND = '#%02x%02x%02x' % (69,79,89)
     OPTION_MENU      = '#%02x%02x%02x' % (196, 173, 201)
+
 
 class Configuration:
     def __init__(self):
@@ -79,6 +82,7 @@ class Configuration:
             exit()
 
         return
+
 
 class Access_Point:
     def __init__(self, ssid, enc, ch, mac, ven, sig):
@@ -116,6 +120,7 @@ class Access_Point:
             pass
         return
 
+
 class Client:
     def __init__(self, mac, bssid, rssi):
         self.mmac   = mac
@@ -128,6 +133,7 @@ class Client:
     def update_network(self, bssid):
         self.mbssid = bssid
         return
+
 
 class MainWindow:
     def __init__(self, master, config):
@@ -444,6 +450,7 @@ class MainWindow:
 
         return
 
+
 # FUNCTIONS
 def handler_beacon(packet):
     global Global_Access_Points
@@ -514,6 +521,7 @@ def handler_beacon(packet):
             Global_My_Gui.add_wifi(Global_Access_Points[source])
     return
 
+
 def handler_data(packet):
     global Global_My_Gui
     global Global_Clients
@@ -554,6 +562,7 @@ def handler_data(packet):
 
     return
 
+
 def handler_eap(packet):
     global Global_My_Gui
     global Global_Clients
@@ -577,6 +586,7 @@ def handler_eap(packet):
             Global_Handshake_Captures += 1
     return
 
+
 def handler_probereq(packet):
     global Global_My_Gui
     global Global_Clients
@@ -596,6 +606,7 @@ def handler_probereq(packet):
 
     return
 
+
 def handler_proberes(packet):
     global Global_Hidden_SSIDs
     global Global_Access_Points
@@ -604,6 +615,7 @@ def handler_proberes(packet):
         Global_Access_Points[packet.addr3].mssid = packet.info
         Global_Hidden_SSIDs.remove(packet.addr3)
     return
+
 
 def get_rssi(DECODED):
     rssi = -(256 - ord(DECODED[-2:-1]))
@@ -615,6 +627,7 @@ def get_rssi(DECODED):
         return "-1"
 
     return rssi
+
 
 def channel_hopper(configuration):
     global Global_Flag
@@ -646,9 +659,11 @@ def channel_hopper(configuration):
         sleep(1.5)
     return
 
+
 def set_size(height, width):
     sys.stdout.write("\x1b[8{rows}{cols}t".format(rows=height, cols=width))
     return
+
 
 def check_valid(mac):
     global Global_Ignore_Broadcast
@@ -659,10 +674,12 @@ def check_valid(mac):
             return True
     return False
 
+
 def create_pcap_filepath():
     if not os.path.isdir("/root/pcaps"):
         os.system("mkdir /root/pcaps")
     return
+
 
 def sniff_packets( packet ):
     global Global_Mac_Filter
@@ -694,12 +711,14 @@ def sniff_packets( packet ):
 
     return
 
+
 def start_gui(configuration):
     global Global_My_Gui
     root = Tk()
     root.wm_attributes('-type', 'splash')
     Global_My_Gui = MainWindow(root, configuration)
     root.mainloop()
+
 
 if __name__ == '__main__':
     configuration = Configuration()

--- a/install.py
+++ b/install.py
@@ -8,7 +8,7 @@ import string
 import subprocess
 
 
-WARNINGS = 0;
+WARNINGS = 0
 
 
 class bcolors:
@@ -25,20 +25,20 @@ class bcolors:
 def Check_Root():
     if os.getuid() != 0:
         print(bcolors.FAIL+"[-] Must be run as root."+bcolors.ENDC)
-        sys.exit(0);
-    return 0;
+        sys.exit(0)
+    return 0
 
 
 def Find_Package_Manager():
-    Package_Managers = ["apt-get", "pacman", "yum"];
+    Package_Managers = ["apt-get", "pacman", "yum"]
 
     for manager in Package_Managers:
-        Default_Package_Manager = os.popen("which "+manager).read();
+        Default_Package_Manager = os.popen("which "+manager).read()
         if Default_Package_Manager not in range(0, 300):
-            return Default_Package_Manager.split("/")[-1].strip();
+            return Default_Package_Manager.split("/")[-1].strip()
 
-    print(bcolors.FAIL+"[-] No Default Package Manager Found"+bcolors.ENDC);
-    sys.exit(0);
+    print(bcolors.FAIL+"[-] No Default Package Manager Found"+bcolors.ENDC)
+    sys.exit(0)
 
 
 def Install_Packages(Package_Manager):
@@ -47,21 +47,21 @@ def Install_Packages(Package_Manager):
                             "libncap-dev", "iw", "tcpdump",
                             "graphviz", "python-gnuplot",
                             "python-crypto"
-                        ];
-    Failed_Packages = [];
+                        ]
+    Failed_Packages = []
 
     for package in Packages_To_Install:
         try:
-            subprocess.check_output([Package_Manager, "install", package, "-y"], stderr=subprocess.STDOUT);
+            subprocess.check_output([Package_Manager, "install", package, "-y"], stderr=subprocess.STDOUT)
             print(bcolors.OKGREEN+"[+] Installed: "+package+bcolors.ENDC)
         except subprocess.CalledProcessError as e:
-            Failed_Packages.append( package );
-            WARNINGS += 1;
+            Failed_Packages.append( package )
+            WARNINGS += 1
 
     if len(Failed_Packages) > 0:
         for item in Failed_Packages:
-            print(bcolors.WARNING+"[-] Failed to install Package: "+item+bcolors.ENDC);
-    return;
+            print(bcolors.WARNING+"[-] Failed to install Package: "+item+bcolors.ENDC)
+    return
 
 
 def Create_Custom_Command():
@@ -84,50 +84,50 @@ def Create_Custom_Command():
 
     for dire in dirs:
         if os.path.isdir(dire):
-            os.system("sudo rm -rf "+dire);
-            print(bcolors.OKGREEN+"[+] Removed Old Project Directory"+bcolors.ENDC);
+            os.system("sudo rm -rf "+dire)
+            print(bcolors.OKGREEN+"[+] Removed Old Project Directory"+bcolors.ENDC)
 
     try:
         subprocess.check_output(["sudo", "cp", "-r", "Packet-Sniffer/", "/usr/share/"], stderr=subprocess.STDOUT)
-        subprocess.check_output(["sudo", "cp", "-r", "Monitor/", "/usr/share/"], stderr=subprocess.STDOUT);
-        subprocess.check_output(["sudo", "cp", "-r", "Deauth/", "/usr/share/"], stderr=subprocess.STDOUT);
+        subprocess.check_output(["sudo", "cp", "-r", "Monitor/", "/usr/share/"], stderr=subprocess.STDOUT)
+        subprocess.check_output(["sudo", "cp", "-r", "Deauth/", "/usr/share/"], stderr=subprocess.STDOUT)
         print(bcolors.OKGREEN+"[+] Installed Tools to: /usr/share/"+bcolors.ENDC)
     except subprocess.CalledProcessError as e:
-        print(e.output);
+        print(e.output)
 
     for link in links:
         if os.path.islink(link):
-            os.system("sudo rm -f "+link);
-            print(bcolors.OKGREEN+"[+] Removed an old command"+bcolors.ENDC);
+            os.system("sudo rm -f "+link)
+            print(bcolors.OKGREEN+"[+] Removed an old command"+bcolors.ENDC)
 
     for index, value in enumerate(new_links):
         try:
-            subprocess.check_output(["sudo", "ln", "-s", new_links[index], links[index]], stderr=subprocess.STDOUT);
-            subprocess.check_output(["sudo", "chmod", "755", links[index]], stderr=subprocess.STDOUT);
+            subprocess.check_output(["sudo", "ln", "-s", new_links[index], links[index]], stderr=subprocess.STDOUT)
+            subprocess.check_output(["sudo", "chmod", "755", links[index]], stderr=subprocess.STDOUT)
             print(bcolors.OKGREEN+"[+] Created New Command"+bcolors.ENDC)
         except subprocess.CalledProcessError as e:
-            print(bcolors.FAIL+"[-] Failed During custom command creation.");
+            print(bcolors.FAIL+"[-] Failed During custom command creation.")
 
-    return 0;
+    return 0
 
 
 def install():
     global WARNINGS
 
-    Check_Root();
+    Check_Root()
 
     print(bcolors.OKBLUE+"""
 ,_,_,_,_,_,_,_,_,_,_|____________________BOOP-INSTALLER____________________
 |#|#|#|#|#|#|#|#|#|#|_____________________________________________________/
 '-'-'-'-'-'-'-'-'-'-|----------------------------------------------------'
                                           M1ND-B3ND3R
-    """+bcolors.ENDC);
+    """+bcolors.ENDC)
 
-    Package_Manager = Find_Package_Manager();
-    Install_Packages(Package_Manager);
-    Create_Custom_Command();
+    Package_Manager = Find_Package_Manager()
+    Install_Packages(Package_Manager)
+    Create_Custom_Command()
 
     print(bcolors.HEADER+"[+] Exiting with: "+str(WARNINGS)+" warnings and 0 Failures.")
 
 
-install();
+install()

--- a/install.py
+++ b/install.py
@@ -130,4 +130,5 @@ def install():
     print(bcolors.HEADER+"[+] Exiting with: "+str(WARNINGS)+" warnings and 0 Failures.")
 
 
-install()
+if __name__ == "__main__":
+    install()

--- a/install.py
+++ b/install.py
@@ -7,7 +7,9 @@ import random
 import string
 import subprocess
 
+
 WARNINGS = 0;
+
 
 class bcolors:
     HEADER = '\033[95m'
@@ -19,11 +21,13 @@ class bcolors:
     BOLD = '\033[1m'
     UNDERLINE = '\033[4m'
 
+
 def Check_Root():
     if os.getuid() != 0:
         print(bcolors.FAIL+"[-] Must be run as root."+bcolors.ENDC)
         sys.exit(0);
     return 0;
+
 
 def Find_Package_Manager():
     Package_Managers = ["apt-get", "pacman", "yum"];
@@ -35,6 +39,7 @@ def Find_Package_Manager():
 
     print(bcolors.FAIL+"[-] No Default Package Manager Found"+bcolors.ENDC);
     sys.exit(0);
+
 
 def Install_Packages(Package_Manager):
     global WARNINGS
@@ -57,6 +62,7 @@ def Install_Packages(Package_Manager):
         for item in Failed_Packages:
             print(bcolors.WARNING+"[-] Failed to install Package: "+item+bcolors.ENDC);
     return;
+
 
 def Create_Custom_Command():
 
@@ -104,6 +110,7 @@ def Create_Custom_Command():
 
     return 0;
 
+
 def install():
     global WARNINGS
 
@@ -121,5 +128,6 @@ def install():
     Create_Custom_Command();
 
     print(bcolors.HEADER+"[+] Exiting with: "+str(WARNINGS)+" warnings and 0 Failures.")
+
 
 install();

--- a/install.py
+++ b/install.py
@@ -1,4 +1,5 @@
-#!/usr/bin/python
+#!/usr/bin/env python
+
 import os
 import sys
 import time


### PR DESCRIPTION
A few style fixes: remove unnecessary semi-colons from `install.py`, shebang lines, PEP8 blank lines (two lines between functions/classes/import), standardize `__name__ = '__main__'` use.